### PR TITLE
chore: update dio, retrofit, and retrofit_generator dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=3.7.0 <4.0.0"
 
 dependencies:
-  dio: ^5.8.0+1
+  dio: ^5.9.0
   mercure_client: ^1.2.0
   dio_smart_retry: ^7.0.1
 
@@ -16,7 +16,7 @@ dependencies:
   # Annotations
   freezed_annotation: ^3.0.0
   json_annotation: ^4.9.0
-  retrofit: ^4.4.2
+  retrofit: ^4.9.1
 
 dev_dependencies:
   lints: ^5.1.1
@@ -26,4 +26,4 @@ dev_dependencies:
   build_runner: ^2.4.15
   freezed: ^3.0.6
   json_serializable: ^6.9.5
-  retrofit_generator: ^9.2.0
+  retrofit_generator: ^10.2.0


### PR DESCRIPTION
Retrofit generator was generating  Error: Too few positional arguments: 4 required, 3 given.